### PR TITLE
Add nginx 1.28 (as default)

### DIFF
--- a/.github/workflows/pr-nginx-tests.yml
+++ b/.github/workflows/pr-nginx-tests.yml
@@ -30,6 +30,7 @@ jobs:
           - examples/1.25
           - examples/1.26
           - examples/1.27
+          - examples/1.28
           - examples/custom
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
-## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
-
 * Added nginx 1.28
 * Changed default version to `1.28`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
+
+* Added nginx 1.28
+* Changed default version to `1.28`
+
 ## v1.4.4 - [December 7, 2024](https://github.com/lando/nginx/releases/tag/v1.4.4)
 
 * Optimized for `midcore`

--- a/builders/nginx.js
+++ b/builders/nginx.js
@@ -8,9 +8,10 @@ const path = require('path');
 module.exports = {
   name: 'nginx',
   config: {
-    version: '1.27',
-    supported: ['1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23', '1.24', '1.25', '1.26', '1.27'],
+    version: '1.28',
+    supported: ['1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23', '1.24', '1.25', '1.26', '1.27', '1.28'],
     pinPairs: {
+      '1.28': 'bitnami/nginx:1.28.0-debian-12-r0',
       '1.27': 'bitnami/nginx:1.27.2-debian-12-r0',
       '1.26': 'bitnami/nginx:1.26.2-debian-12-r6',
       '1.25': 'bitnami/nginx:1.25.5-debian-12-r7',

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,8 @@ services:
 
 ## Supported versions
 
-*   **[1.27](https://hub.docker.com/r/bitnami/nginx/tags?name=1.27)** **(default)**
+*   **[1.28](https://hub.docker.com/r/bitnami/nginx/tags?name=1.28)** **(default)**
+*   [1.27](https://hub.docker.com/r/bitnami/nginx/tags?name=1.27)
 *   [1.26](https://hub.docker.com/r/bitnami/nginx/tags?name=1.26)
 *   [1.25](https://hub.docker.com/r/bitnami/nginx/tags?name=1.25)
 *   [1.24](https://hub.docker.com/r/bitnami/nginx/tags?name=1.24)

--- a/examples/1.28/.lando.yml
+++ b/examples/1.28/.lando.yml
@@ -1,0 +1,11 @@
+name: lando-nginx-128
+services:
+  defaults:
+    type: nginx:1.28
+    build_as_root:
+      - apt-get update && apt-get install -y curl
+
+# This is important because it lets lando know to test against the plugin in this repo
+# DO NOT REMOVE THIS!
+plugins:
+  "@lando/nginx": ../..

--- a/examples/1.28/README.md
+++ b/examples/1.28/README.md
@@ -1,0 +1,44 @@
+nginx Example
+=============
+
+This example exists primarily to test the following documentation:
+
+* [nginx Service](https://docs.devwithlando.io/tutorials/nginx.html)
+
+Start up tests
+--------------
+
+Run the following commands to get up and running with this example.
+
+```bash
+# Should start up successfully
+lando poweroff
+lando start
+```
+
+Verification commands
+---------------------
+
+Run the following commands to validate things are rolling as they should.
+
+```bash
+# Should use 1.28.x as the default version
+lando ssh -s defaults -c "nginx -v 2>&1 | grep 1.28"
+
+# Should serve from the app root by default
+lando ssh -s defaults -c "curl -s http://localhost | grep ROOTDIR"
+
+# Should only serve over http by default
+lando ssh -s defaults -c "curl -s --write-out \"%{exitcode}\" https://localhost | grep 7"
+```
+
+Destroy tests
+-------------
+
+Run the following commands to trash this app like nothing ever happened.
+
+```bash
+# Should be destroyed with success
+lando destroy -y
+lando poweroff
+```

--- a/examples/1.28/index.html
+++ b/examples/1.28/index.html
@@ -1,0 +1,1 @@
+ROOTDIR


### PR DESCRIPTION
### Bare minimum self-checks

- [x] I've updated this PR with the latest code from `main`
- [x] I've done a cursory QA pass of my code locally
- [x] I've ensured all automated status check and tests pass
- [ ] I've [connected this PR to an issue](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues)

### Pieces of flare

- [x] I've written a unit or functional test for my code
- [x] I've updated relevant documentation it my code changes it
- [x] I've updated this repo's README if my code changes it
- [x] I've updated this repo's CHANGELOG with my change unless its a trivial change (like updating a typo in the docs)

### Finally

- [ ] I've [requested a review](https://help.github.com/en/articles/requesting-a-pull-request-review) with relevant people
