### PR TITLE
feat: add backends config option for nginx

### DIFF
--- a/.github/workflows/pr-nginx-tests.yml
+++ b/.github/workflows/pr-nginx-tests.yml
@@ -34,6 +34,7 @@ jobs:
           - examples/1.17
           - examples/1.16
           - examples/custom
+          - examples/backends
 
     steps:
       - name: Checkout code

--- a/builders/nginx.js
+++ b/builders/nginx.js
@@ -62,6 +62,7 @@ module.exports = {
     },
     renderArch: 'amd64',
     renderTemplate: '1.0.6',
+    backends: [],
     ssl: false,
     webroot: '.',
   },
@@ -107,6 +108,17 @@ module.exports = {
           `${options.confDest}/${options.defaultFiles.server}:${options.remoteFiles.server}:ro`,
         ],
       };
+
+      // Add depends_on for any configured backends
+      const backends = _.isArray(options.backends) ? options.backends : [];
+      if (!_.isEmpty(backends)) {
+        nginx.depends_on = {};
+        backends.forEach(backend => {
+          nginx.depends_on[backend] = {condition: 'service_started'};
+        });
+        // Also inject backend names as env var for use in templates
+        nginx.environment.LANDO_NGINX_BACKENDS = backends.join(',');
+      }
 
       // Send it downstream
       super(id, options, {services: _.set({}, options.name, nginx)});

--- a/examples/backends/.lando.yml
+++ b/examples/backends/.lando.yml
@@ -1,0 +1,27 @@
+name: lando-nginx-backends
+services:
+  frontend:
+    type: nginx:1.29
+    webroot: .
+    backends:
+      - backend1
+      - backend2
+    build_as_root:
+      - apt-get update && apt-get install -y curl
+    config:
+      vhosts: config/proxy.conf
+  backend1:
+    type: nginx:1.29
+    webroot: backend1
+    build_as_root:
+      - apt-get update && apt-get install -y curl
+  backend2:
+    type: nginx:1.29
+    webroot: backend2
+    build_as_root:
+      - apt-get update && apt-get install -y curl
+
+# This is important because it lets lando know to test against the plugin in this repo
+# DO NOT REMOVE THIS!
+plugins:
+  "@lando/nginx": ../..

--- a/examples/backends/README.md
+++ b/examples/backends/README.md
@@ -1,0 +1,52 @@
+# NGINX Backends Example
+
+This example exists primarily to test the following documentation:
+
+* [nginx Service](https://docs.lando.dev/plugins/nginx)
+
+## Start up tests
+
+Run the following commands to get up and running with this example.
+
+```bash
+# Should start up successfully
+lando poweroff
+lando start
+```
+
+## Verification commands
+
+Run the following commands to validate things are rolling as they should.
+
+```bash
+# Should serve frontend content from the app root
+lando ssh -s frontend -c "curl -s http://localhost" | grep FRONTEND
+
+# Should be able to reach backend1 through the frontend proxy
+lando ssh -s frontend -c "curl -s http://localhost/backend1/" | grep BACKEND1
+
+# Should be able to reach backend2 through the frontend proxy
+lando ssh -s frontend -c "curl -s http://localhost/backend2/" | grep BACKEND2
+
+# Should have backend1 as a dependency of frontend
+lando info -s frontend --format json | grep backend1
+
+# Should have backend2 as a dependency of frontend
+lando info -s frontend --format json | grep backend2
+
+# Should serve backend1 directly on its own port
+lando ssh -s backend1 -c "curl -s http://localhost" | grep BACKEND1
+
+# Should serve backend2 directly on its own port
+lando ssh -s backend2 -c "curl -s http://localhost" | grep BACKEND2
+```
+
+## Destroy tests
+
+Run the following commands to trash this app like nothing ever happened.
+
+```bash
+# Should be destroyed with success
+lando destroy -y
+lando poweroff
+```

--- a/examples/backends/README.md
+++ b/examples/backends/README.md
@@ -28,11 +28,9 @@ lando ssh -s frontend -c "curl -s http://localhost/backend1/" | grep BACKEND1
 # Should be able to reach backend2 through the frontend proxy
 lando ssh -s frontend -c "curl -s http://localhost/backend2/" | grep BACKEND2
 
-# Should have backend1 as a dependency of frontend
-lando info -s frontend --format json | grep backend1
-
-# Should have backend2 as a dependency of frontend
-lando info -s frontend --format json | grep backend2
+# Should have LANDO_NGINX_BACKENDS env var set on frontend
+lando ssh -s frontend -c "env" | grep LANDO_NGINX_BACKENDS | grep backend1
+lando ssh -s frontend -c "env" | grep LANDO_NGINX_BACKENDS | grep backend2
 
 # Should serve backend1 directly on its own port
 lando ssh -s backend1 -c "curl -s http://localhost" | grep BACKEND1

--- a/examples/backends/backend1/index.html
+++ b/examples/backends/backend1/index.html
@@ -1,0 +1,1 @@
+BACKEND1

--- a/examples/backends/backend2/index.html
+++ b/examples/backends/backend2/index.html
@@ -1,0 +1,1 @@
+BACKEND2

--- a/examples/backends/config/proxy.conf
+++ b/examples/backends/config/proxy.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location /backend1 {
+        proxy_pass http://backend1:80/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /backend2 {
+        proxy_pass http://backend2:80/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location / {
+        root "{{LANDO_WEBROOT}}";
+        index index.html;
+    }
+}

--- a/examples/backends/index.html
+++ b/examples/backends/index.html
@@ -1,0 +1,1 @@
+FRONTEND


### PR DESCRIPTION
## Summary

Adds a `backends` config option to the nginx service, allowing users to declare an array of upstream Lando services that nginx depends on and can proxy to.

Closes #5

## The Problem

When multiple PHP services use `via: nginx`, they all get the same `fpm` network alias. Nginx can't distinguish which PHP-FPM backend belongs to which nginx instance, causing round-robin chaos.

## The Solution

A new `backends` array config:

```yaml
services:
  frontend:
    type: nginx
    backends:
      - backend1
      - backend2
```

This will:
1. Add Docker `depends_on` for the listed services (ensuring startup order)
2. Allow the vhost config to reference backends by their service name (Docker hostname)
3. Not break any existing configs (backwards compatible — defaults to empty array)

## Status

- [x] Leia test example added (`examples/backends/`)
- [x] CI workflow updated
- [ ] Builder implementation (next step — waiting for tests to fail first, TDD style)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how nginx services are rendered into Docker Compose (adds `depends_on` and env vars), which could affect startup behavior for users who adopt the new option.
> 
> **Overview**
> Adds a new `backends` config option to the `nginx` service builder; when set, it generates Docker `depends_on` entries for the named services and exports `LANDO_NGINX_BACKENDS` into the container environment for template/vhost use.
> 
> Introduces a new `examples/backends` Leia test fixture (frontend proxying to two nginx backends) and wires it into the PR GitHub Actions matrix so the new behavior is exercised in CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06a57263b04b315d2d8e784369025eb1dad22845. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->