### PR TITLE
fix: handle race condition in release promote job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,20 @@ jobs:
         run: |
           VERSION=$(echo "$TAG_NAME" | sed 's/^v//')
           PACKAGE=$(node -p "require('./package.json').name")
-          npm dist-tag add "$PACKAGE@$VERSION" latest
-          echo "::notice title=Promoted $VERSION to latest::The latest tag now points to $VERSION (was edge-only)"
+
+          # Wait for version to be available on npm (handles race with deploy job)
+          for i in $(seq 1 30); do
+            if npm view "$PACKAGE@$VERSION" version &>/dev/null; then
+              npm dist-tag add "$PACKAGE@$VERSION" latest
+              echo "::notice title=Promoted $VERSION to latest::The latest tag now points to $VERSION"
+              exit 0
+            fi
+            echo "Waiting for $PACKAGE@$VERSION on npm... (attempt $i/30)"
+            sleep 10
+          done
+
+          echo "::error title=Promotion failed::$PACKAGE@$VERSION not found on npm after 5 minutes"
+          exit 1
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
           NODE_AUTH_TOKEN: ${{secrets.NPM_DEPLOY_TOKEN}}


### PR DESCRIPTION
## Problem

When a fresh (non-prerelease) release is created, GitHub fires both `published` and `released` events simultaneously. The `promote` job (triggered by `released`) races the `deploy` job (triggered by `published`) and tries to `npm dist-tag add` before the package is published to npm.

## Fix

Add a retry loop that waits up to 5 minutes for the package version to appear on npm before promoting. If the version never appears, the job fails with a clear error instead of silently succeeding.

This is better than simply skipping when the version doesn't exist (as in lando/phpmyadmin#72), because it still catches genuine failures — e.g., if a prerelease promotion runs and the version is truly missing.

## Affected repos

This same fix is being rolled out to all Lando repos with this release workflow pattern.

Closes any race condition failures on the `promote` job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adds waiting/retry logic around `npm dist-tag` promotion; risk is limited to release workflow timing and potential delayed/failing promotions.
> 
> **Overview**
> Prevents a race in `.github/workflows/release.yml` where the `promote` job could run before the `deploy` job has published the version to npm.
> 
> The `promote` step now polls `npm view` for up to 5 minutes before running `npm dist-tag add ... latest`, and fails with an explicit error if the version never appears.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 066a13835fdf5ccabcd13cb6a3f7c2e998a11a79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->